### PR TITLE
add support for $search query option

### DIFF
--- a/lib/odata-parser.js
+++ b/lib/odata-parser.js
@@ -97,6 +97,7 @@ module.exports = (function(){
         "selectList": parse_selectList,
         "filter": parse_filter,
         "filterExpr": parse_filterExpr,
+        "search": parse_search,
         "booleanFunctions2Args": parse_booleanFunctions2Args,
         "booleanFunc": parse_booleanFunc,
         "otherFunctions1Arg": parse_otherFunctions1Arg,
@@ -4094,6 +4095,119 @@ module.exports = (function(){
         return result0;
       }
 
+      function parse_search() {
+        var result0, result1, result2;
+        var pos0, pos1;
+
+        pos0 = pos;
+        pos1 = pos;
+        if (input.substr(pos, 8) === "$search=") {
+          result0 = "$format=";
+          pos += 8;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"$search=\"");
+          }
+        }
+        if (result0 !== null) {
+          if (input.length > pos) {
+            result2 = input.charAt(pos);
+            pos++;
+          } else {
+            result2 = null;
+            if (reportFailures === 0) {
+              matchFailed("any character");
+            }
+          }
+          if (result2 !== null) {
+            result1 = [];
+            while (result2 !== null) {
+              result1.push(result2);
+              if (input.length > pos) {
+                result2 = input.charAt(pos);
+                pos++;
+              } else {
+                result2 = null;
+                if (reportFailures === 0) {
+                  matchFailed("any character");
+                }
+              }
+            }
+          } else {
+            result1 = null;
+          }
+          if (result1 !== null) {
+            result0 = [result0, result1];
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, v) { return {'$search': v.join('') }; })(pos0, result0[1]);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        if (result0 === null) {
+          pos0 = pos;
+          pos1 = pos;
+          if (input.substr(pos, 8) === "$search=") {
+            result0 = "$search=";
+            pos += 8;
+          } else {
+            result0 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"$search=\"");
+            }
+          }
+          if (result0 !== null) {
+            result1 = [];
+            if (input.length > pos) {
+              result2 = input.charAt(pos);
+              pos++;
+            } else {
+              result2 = null;
+              if (reportFailures === 0) {
+                matchFailed("any character");
+              }
+            }
+            while (result2 !== null) {
+              result1.push(result2);
+              if (input.length > pos) {
+                result2 = input.charAt(pos);
+                pos++;
+              } else {
+                result2 = null;
+                if (reportFailures === 0) {
+                  matchFailed("any character");
+                }
+              }
+            }
+            if (result1 !== null) {
+              result0 = [result0, result1];
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+          if (result0 !== null) {
+            result0 = (function(offset) { return {"error": 'invalid $search parameter'}; })(pos0);
+          }
+          if (result0 === null) {
+            pos = pos0;
+          }
+        }
+        return result0;
+      }
+
       function parse_booleanFunctions2Args() {
         var result0;
 
@@ -5217,9 +5331,12 @@ module.exports = (function(){
                     if (result0 === null) {
                       result0 = parse_select();
                       if (result0 === null) {
-                        result0 = parse_callback();
+                        result0 = parse_search();
                         if (result0 === null) {
-                          result0 = parse_unsupported();
+                          result0 = parse_callback();
+                          if (result0 === null) {
+                            result0 = parse_unsupported();
+                          }
                         }
                       }
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanetix/odata-parser",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "OData query string parser",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
lanetix/issues#2892 

http://docs.oasis-open.org/odata/odata/v4.0/errata01/os/complete/part2-url-conventions/odata-v4.0-errata01-os-part2-url-conventions-complete.html#_Toc395267184

### 5.1.7 System Query Option $search

> Example 104: all products that are blue or green. It is up to the service to decide what makes a product blue or green.

`http://host/service/Products?$search=blue OR green`

### 5.1.7.1 Search Expressions

> Each individual term or phrase comprises a Boolean expression that returns true if the term or phrase is matched, otherwise false. The semantics of what is considered a match is dependent upon the service.

`$search` is very loosely (rather open about what we get to decide different stuff means) documented right now. In theory you could do stuff like `this OR that`, but we'll just treat everything as a literal right now instead of trying to sort out a more complex range of operators. i.e. `OR`, `AND`, `NOT`, `()`. These will have no special meaning for us. They'll just be treated as literal values instead of operators. This shall suit our needs and I doubt we'll ever need anything more. A lot about how the search value gets interpreted is up to the consumer of the actual uri/query itself ("the service"), but ****shrugs****. We'll just be pragmatic about it and call it a day.

These guys would need to patch [this](https://github.com/lanetix/ui-records-list/blob/34443fe38140e277aa0d163a7936d1cc95bdc41e/client/stores/table-view.js#L62) accordingly (as it currently stands that code does has absolutely 0 meaning).