### PR TITLE
fix: literal filters should accept quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib/odata-parser.js
+.project

--- a/lib/odata-parser.js
+++ b/lib/odata-parser.js
@@ -81,6 +81,7 @@ module.exports = (function(){
         "nanInfinity": parse_nanInfinity,
         "unreserved": parse_unreserved,
         "validstring": parse_validstring,
+        "escapedQuote": parse_escapedQuote,
         "identifierPart": parse_identifierPart,
         "identifier": parse_identifier,
         "QCHAR_NO_AMP_DQUOTE": parse_QCHAR_NO_AMP_DQUOTE,
@@ -2616,6 +2617,9 @@ module.exports = (function(){
             matchFailed("[^']");
           }
         }
+        if (result1 === null) {
+          result1 = parse_escapedQuote();
+        }
         while (result1 !== null) {
           result0.push(result1);
           if (/^[^']/.test(input.charAt(pos))) {
@@ -2627,9 +2631,35 @@ module.exports = (function(){
               matchFailed("[^']");
             }
           }
+          if (result1 === null) {
+            result1 = parse_escapedQuote();
+          }
         }
         if (result0 !== null) {
-          result0 = (function(offset, a) { return a.join(''); })(pos0, result0);
+          result0 = (function(offset, a) { return a.join('').replace(/('')/g, "'"); })(pos0, result0);
+        }
+        if (result0 === null) {
+          pos = pos0;
+        }
+        return result0;
+      }
+      
+      function parse_escapedQuote() {
+        var result0;
+        var pos0;
+        
+        pos0 = pos;
+        if (input.substr(pos, 2) === "''") {
+          result0 = "''";
+          pos += 2;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"''\"");
+          }
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, a) { return a; })(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -165,7 +165,8 @@ unreserved                  = [a-zA-Z0-9-_]
 //pctEncodedUnescaped =       = "%" [01346789A-F] HEXDIG
 //                            / "%2" [013456789A-F]
 //                            / "%5" [0-9ABDEF]
-validstring                 = a:[^']* { return a.join(''); }
+validstring                 = a:([^']/escapedQuote)* { return a.join('').replace(/('')/g, "'"); }
+escapedQuote                = a:"''" { return a; }
 identifierPart              = a:[a-zA-Z] b:unreserved* { return a + b.join(''); }
 identifier                  =
                                 a:identifierPart list:("." i:identifier {return i;})? {

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -97,6 +97,26 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.value, "Jef");
     });
 
+    it('should parse $filter containing quote', function () {
+
+        var ast = parser.parse("$filter=Name eq 'O''Neil'");
+
+        assert.equal(ast.$filter.type, "eq");
+        assert.equal(ast.$filter.left.type, "property");
+        assert.equal(ast.$filter.left.name, "Name");
+        assert.equal(ast.$filter.right.type, "literal");
+        assert.equal(ast.$filter.right.value, "O'Neil");
+    });
+
+    it('should parse $filter with subproperty', function () {
+      	var ast = parser.parse("$filter=User/Name eq 'Jef'");
+      	assert.equal(ast.$filter.type, "eq");
+      	assert.equal(ast.$filter.left.type, "property");
+      	assert.equal(ast.$filter.left.name, "User/Name");
+      	assert.equal(ast.$filter.right.type, "literal");
+      	assert.equal(ast.$filter.right.value, "Jef");
+    });
+
     it('should parse multiple conditions in a $filter', function () {
 
         var ast = parser.parse("$filter=Name eq 'John' and LastName lt 'Doe'");
@@ -135,6 +155,32 @@ describe('odata.parser grammar', function () {
 
         assert.equal(ast.$filter.args[0].type, "literal");
         assert.equal(ast.$filter.args[0].value, "");
+
+    });
+
+    it('should parse substringof $filter with string containing quote', function () {
+
+      var ast = parser.parse("$filter=substringof('ng''inx', Data)");
+      assert.equal(ast.$filter.args[0].type, "literal");
+      assert.equal(ast.$filter.args[0].value, "ng'inx");
+
+    });
+
+    it('should parse substringof $filter with string starting with quote', function () {
+
+      var ast = parser.parse("$filter=substringof('''nginx', Data)");
+
+      assert.equal(ast.$filter.args[0].type, "literal");
+      assert.equal(ast.$filter.args[0].value, "'nginx");
+
+    });
+
+    it('should parse substringof $filter with string ending with quote', function () {
+
+      var ast = parser.parse("$filter=substringof('nginx''', Data)");
+
+      assert.equal(ast.$filter.args[0].type, "literal");
+      assert.equal(ast.$filter.args[0].value, "nginx'");
 
     });
 
@@ -342,12 +388,6 @@ describe('odata.parser grammar', function () {
         var ast = parser.parse("$callback=jQuery191039675481244921684_1424879147656");
         assert.equal(ast.$callback, "jQuery191039675481244921684_1424879147656");
     });
-
-    // it('xxxxx', function () {
-    //     var ast = parser.parse("$top=2&$filter=Date gt datetime'2012-09-27T21:12:59'");
-
-    //     console.log(JSON.stringify(ast, 0, 2));
-    // });
 });
 
 describe('odata path parser grammar', function () {


### PR DESCRIPTION
@lanetix/engineers CR plz

This is a fix from the parent of this fork. Add support for escaping single quotes with double single quotes, `''`.

Original commit message follows.

> According to OData documentation : "One of these rules is that single quotes within string literals are represented as two consecutive single quotes.".
> 
> http://docs.oasis-open.org/odata/odata/v4.0/odata-v4.0-part2-url-conventions.html