### PR TITLE
changed property name on 1 node. Other minor trickle-down changes.

### DIFF
--- a/lib/odata-parser.js
+++ b/lib/odata-parser.js
@@ -4971,7 +4971,7 @@ module.exports = (function(){
         if (result0 !== null) {
           result0 = (function(offset, p, arg0) {
                                           return {
-                                              path: p.idPath,
+                                              name: p.idPath,
                                               type: "functioncall",
                                               func: p.func,
                                               args: [arg0]

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -373,7 +373,7 @@ otherFunc1                  = f:otherFunctions1Arg "(" arg0:part ")" {
 
 collectionFuncExpr         = p:idPathANDfuncArgExpr "(" arg0:lambdaFunc ")" {
                                   return {
-                                      path: p.idPath,
+                                      name: p.idPath,
                                       type: "functioncall",
                                       func: p.func,
                                       args: [arg0]

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -239,7 +239,7 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.type, "eq");
 
         assert.equal(ast.$filter.left.type, "functioncall");
-        assert.equal(ast.$filter.left.path, "linked_table/any_num_hops/string_list");
+        assert.equal(ast.$filter.left.name, "linked_table/any_num_hops/string_list");
         assert.equal(ast.$filter.left.func, "any");
 
         assert.equal(ast.$filter.left.args[0].type, "eq");
@@ -258,7 +258,7 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.type, "eq");
 
         assert.equal(ast.$filter.left.type, "functioncall");
-        assert.equal(ast.$filter.left.path, "linked_table/any_num_hops/string_list");
+        assert.equal(ast.$filter.left.name, "linked_table/any_num_hops/string_list");
         assert.equal(ast.$filter.left.func, "all");
 
         assert.equal(ast.$filter.left.args[0].type, "eq");


### PR DESCRIPTION
The odata-mapper requires this property to be node.name.  (Not node.path.) Since "name" is the special property used by the recursive visitor.

Tests passed.

This current PR here must be first merged, before the mapper-PR will work:
https://github.com/lanetix/node-lanetix-list-query-mapper/pull/92
