### PR TITLE
Remove arrow function

### DIFF
--- a/add.flow.js
+++ b/add.flow.js
@@ -47,7 +47,7 @@ fs.writeFileSync(parserPath, babel.transform(
   `function peg$computePosDetails(pos /*: number */) {`
 ).replace(
   `var ODataAST = _flowRuntime2`,
-  `var ODataAST1 = (() => {\nvar ODataAST = _flowRuntime2`
+  `var ODataAST1 = (function () {\nvar ODataAST = _flowRuntime2`
 ).replace(
   `return ODataAST;`,
   `return ODataAST1`

--- a/lib/index.js
+++ b/lib/index.js
@@ -8862,7 +8862,7 @@ exports.default = {
   parse: peg$parse
 };
 
-var ODataAST1 = (() => {
+var ODataAST1 = (function () {
 var ODataAST = _flowRuntime2.default.type("ODataAST", _flowRuntime2.default.union(_flowRuntime2.default.exactObject(_flowRuntime2.default.property("$path", _flowRuntime2.default.tdz(function () {
   return $path;
 }, "$path"), true), _flowRuntime2.default.property("$select", _flowRuntime2.default.tdz(function () {


### PR DESCRIPTION
To make this lib work in `ui`, I had to get rid of the arrow function in the Parser so it can work through the uglify process.

This is part of a long process to get the parser and the ast transformations to compile correctly in the prod build of the UI.

Will publish a **PATCH** after merging this in. #